### PR TITLE
refactor!: use listen address instead of port, change default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,4 @@ COPY *.go ./
 
 RUN go build -o /someguy
 
-EXPOSE 8190
-
-CMD [ "/someguy", "start", "--listen-address", "0.0.0.0:8190" ]
+CMD [ "/someguy", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY *.go ./
 
 RUN go build -o /someguy
 
-EXPOSE 8080
+EXPOSE 8190
 
-CMD [ "/someguy", "start", "--port", "8080" ]
+CMD [ "/someguy", "start", "--listen-address", "0.0.0.0:8190" ]

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -3,7 +3,7 @@
 `someguy` ships with some implicit defaults that can be adjusted via env variables below.
 
 - [Configuration](#configuration)
-  - [`SOMEGUY_PORT`](#someguy_port)
+  - [`SOMEGUY_LISTEN_ADDRESS`](#someguy_listen_address)
   - [`SOMEGUY_ACCELERATED_DHT`](#someguy_accelerated_dht)
   - [`SOMEGUY_PROVIDER_ENDPOINTS`](#someguy_provider_endpoints)
   - [`SOMEGUY_PEER_ENDPOINTS`](#someguy_peer_endpoints)
@@ -16,11 +16,11 @@
 
 ## Configuration
 
-### `SOMEGUY_PORT`
+### `SOMEGUY_LISTEN_ADDRESS`
 
-The port to listen on to.
+The address to listen on.
 
-Default: `8080`
+Default: `127.0.0.1:8190`
 
 ### `SOMEGUY_ACCELERATED_DHT`
 

--- a/main.go
+++ b/main.go
@@ -22,11 +22,11 @@ func main() {
 			{
 				Name: "start",
 				Flags: []cli.Flag{
-					&cli.IntFlag{
-						Name:    "port",
-						Value:   8080,
-						EnvVars: []string{"SOMEGUY_PORT"},
-						Usage:   "port to serve requests on",
+					&cli.StringFlag{
+						Name:    "listen-address",
+						Value:   "127.0.0.1:8190",
+						EnvVars: []string{"SOMEGUY_LISTEN_ADDRESS"},
+						Usage:   "listen address",
 					},
 					&cli.BoolFlag{
 						Name:    "accelerated-dht",
@@ -54,7 +54,7 @@ func main() {
 					},
 				},
 				Action: func(ctx *cli.Context) error {
-					return start(ctx.Context, ctx.Int("port"), ctx.Bool("accelerated-dht"), ctx.StringSlice("provider-endpoints"), ctx.StringSlice("peer-endpoints"), ctx.StringSlice("ipns-endpoints"))
+					return start(ctx.Context, ctx.String("listen-address"), ctx.Bool("accelerated-dht"), ctx.StringSlice("provider-endpoints"), ctx.StringSlice("peer-endpoints"), ctx.StringSlice("ipns-endpoints"))
 				},
 			},
 			{


### PR DESCRIPTION
Closes #47.

Changes default port to 8190, and changes from port to listen address config.

After this, we may need to update the infra.