### PR TITLE
feat!: ask delegated-ipfs.dev in addition to DHT and cid.contact

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ You can use `someguy` as a client, or as a server.
 
 ### Server
 
-You can start the server with `someguy start`. This will, by default, run a Delegated Routing V1 server that proxies requests to the [IPFS Amino DHT](https://blog.ipfs.tech/2023-09-amino-refactoring/) and the [cid.contact](https://cid.contact) indexer (IPNI) node.
+You can start the server with `someguy start`. This will, by default, run a Delegated Routing V1 server that proxies requests to the [IPFS Amino DHT](https://blog.ipfs.tech/2023-09-amino-refactoring/), [delegated-ipfs.dev](https://delegated-ipfs.dev) and [cid.contact](https://cid.contact).
 
 For more details run `someguy start --help`.
 
 ### Client
 
-If you don't want to run a server yourself, but want to query some other server, you can run `someguy ask` and choose any of the subcommands and ask for a provider, a peer, or even an IPNS record.
+If you don't want to run a server yourself, but want to query some other server, you can run `someguy ask` and choose any of the subcommands and ask for a provider, a peer, or even an IPNS record. By default, [delegated-ipfs.dev](https://delegated-ipfs.dev) is the server used.
 
 For more details run `someguy ask --help`.
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -32,19 +32,19 @@ Default: `true`
 
 Comma-separated list of other Delegated Routing V1 endpoints to proxy provider requests to.
 
-Default: `https://cid.contact`
+Default: `https://cid.contact,https://delegated-ipfs.dev`
 
 ### `SOMEGUY_PEER_ENDPOINTS`
 
 Comma-separated list of other Delegated Routing V1 endpoints to proxy peer requests to.
 
-Default: none
+Default: `https://delegated-ipfs.dev`
 
 ### `SOMEGUY_IPNS_ENDPOINTS`
 
 Comma-separated list of other Delegated Routing V1 endpoints to proxy IPNS requests to.
 
-Default: none
+Default: `https://delegated-ipfs.dev`
 
 ## Logging
 

--- a/main.go
+++ b/main.go
@@ -12,7 +12,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const cidContactEndpoint = "https://cid.contact"
+const (
+	cidContactEndpoint    = "https://cid.contact"
+	delegatedIpfsEndpoint = "https://delegated-ipfs.dev"
+)
 
 func main() {
 	app := &cli.App{
@@ -36,19 +39,19 @@ func main() {
 					},
 					&cli.StringSliceFlag{
 						Name:    "provider-endpoints",
-						Value:   cli.NewStringSlice(cidContactEndpoint),
+						Value:   cli.NewStringSlice(cidContactEndpoint, delegatedIpfsEndpoint),
 						EnvVars: []string{"SOMEGUY_PROVIDER_ENDPOINTS"},
 						Usage:   "other Delegated Routing V1 endpoints to proxy provider requests to",
 					},
 					&cli.StringSliceFlag{
 						Name:    "peer-endpoints",
-						Value:   cli.NewStringSlice(),
+						Value:   cli.NewStringSlice(delegatedIpfsEndpoint),
 						EnvVars: []string{"SOMEGUY_PEER_ENDPOINTS"},
 						Usage:   "other Delegated Routing V1 endpoints to proxy peer requests to",
 					},
 					&cli.StringSliceFlag{
 						Name:    "ipns-endpoints",
-						Value:   cli.NewStringSlice(),
+						Value:   cli.NewStringSlice(delegatedIpfsEndpoint),
 						EnvVars: []string{"SOMEGUY_IPNS_ENDPOINTS"},
 						Usage:   "other Delegated Routing V1 endpoints to proxy IPNS requests to",
 					},
@@ -62,7 +65,7 @@ func main() {
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:  "endpoint",
-						Value: cidContactEndpoint,
+						Value: delegatedIpfsEndpoint,
 						Usage: "the Delegated Routing V1 endpoint to ask",
 					},
 					&cli.BoolFlag{


### PR DESCRIPTION
This PR makes two changes:

1. Changes the default from `ask` from cid.contact to delegated-ipfs.dev
2. Adds delegated-ipfs.dev as a default router for the server

Tackles task in #24.