### PR TITLE
chore: update boxo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,6 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- Upgraded Boxo with fix to ensure that `/routing/v1/peers` endpoint accepts all variants of Peer IDs that are seen in the wild.
+
 ### Security

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/CAFxX/httpcompression v0.0.9
 	github.com/felixge/httpsnoop v1.0.4
-	github.com/ipfs/boxo v0.19.1-0.20240415103851-7f9506844904
+	github.com/ipfs/boxo v0.19.1-0.20240515083429-ac0bab3926a8
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/libp2p/go-libp2p v0.33.2

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/ipfs/boxo v0.19.1-0.20240415103851-7f9506844904 h1:HqjqN6oADXh1UNw8xKnBP50B3ZQDC/RStiBFPp6W+9Y=
-github.com/ipfs/boxo v0.19.1-0.20240415103851-7f9506844904/go.mod h1:hA9Ou/YnfMZOG2nQhngsbBiYt6fiJ1EhWSmccZfV+M0=
+github.com/ipfs/boxo v0.19.1-0.20240515083429-ac0bab3926a8 h1:tQoB09dD64FAeXhmjgcL36wcdiN4wp/WZtk5VVijpo8=
+github.com/ipfs/boxo v0.19.1-0.20240515083429-ac0bab3926a8/go.mod h1:hA9Ou/YnfMZOG2nQhngsbBiYt6fiJ1EhWSmccZfV+M0=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=
 github.com/ipfs/go-cid v0.4.1/go.mod h1:uQHwDeX4c6CtyrFwdqyhpNcxVewur1M7l7fNU7LKwZk=


### PR DESCRIPTION
Includes fix: https://github.com/ipfs/boxo/pull/609