### PR TITLE
fix: filter out private addresses when only using dht

### DIFF
--- a/server.go
+++ b/server.go
@@ -155,7 +155,7 @@ func newHost(highOutboundLimits bool) (host.Host, error) {
 
 func getCombinedRouting(endpoints []string, dht routing.Routing) (router, error) {
 	if len(endpoints) == 0 {
-		return libp2pRouter{routing: dht}, nil
+		return sanitizeRouter{libp2pRouter{routing: dht}}, nil
 	}
 
 	var routers []router


### PR DESCRIPTION
This should fix #28 once and for all. We were not applying the `sanitizeRouter` when the endpoint only had a DHT. By default, this is the case for the peers and the ipns endpoint. That's why we were still seeing private addresses on the peers endpoint.