### PR TITLE
refactor(ci): automate docker releases on tag pushes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,38 +5,13 @@ on:
   push:
     branches: ['main', 'staging']
     tags: ['v*']
-  workflow_run:
-    workflows: [Releaser]
-    types:
-      - completed
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  prepare_checkout:
-    if: (
-          github.repository == 'ipfs/someguy'
-          || github.event_name == 'workflow_dispatch'
-        ) && (
-          github.event_name != 'workflow_run'
-          || github.event.workflow_run.conclusion == 'success'
-        )
-    name: Decide what ref to check out
-    runs-on: ubuntu-latest
-    outputs:
-      ref: ${{ github.event_name != 'workflow_run' && github.ref || steps.releaser.outputs.version }}
-    steps:
-      - name: Inspect triggering Releaser workflow run
-        id: releaser
-        if: github.event_name == 'workflow_run'
-        uses: ipdxco/unified-github-workflows/.github/actions/inspect-releaser@v1.0
-        with:
-          artifacts-url: ${{ github.event.workflow_run.artifacts_url }}
   build-and-push-image:
-    needs: [prepare_checkout]
-    if: needs.prepare_checkout.outputs.ref != ''
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -45,7 +20,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.prepare_checkout.outputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -15,3 +15,5 @@ concurrency:
 jobs:
   releaser:
     uses: ipdxco/unified-github-workflows/.github/workflows/releaser.yml@v1.0
+    secrets:
+      UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}


### PR DESCRIPTION
This is the same set of changes as introduced in https://github.com/ipfs/rainbow/pull/138

I have already set up the UCI_GITHUB_TOKEN secret. The token belongs to web3-bot and is limited to access to someguy only.