### PR TITLE
fix: graceful shutdown and interrupt handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,15 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- boxo 0.21
+- go-libp2p 0.35
+
 ### Removed
 
 ### Fixed
 
-- Release tag version is now included in `--version` output.
+- `--version` now includes the release tag
+- `start` command supports a graceful shutdown and improved handling of interrupt signals
 
 ### Security
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.22.4
 
 require (
 	github.com/CAFxX/httpcompression v0.0.9
+	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/felixge/httpsnoop v1.0.4
 	github.com/ipfs/boxo v0.21.0
@@ -33,7 +34,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/cgroups v1.1.0 // indirect
-	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect


### PR DESCRIPTION
This PR aims to fix interrupt handling when <kbd>^C</kbd> is hit in terminal (a regression detected in https://github.com/ipfs/someguy/pull/72, so PR against that). 

It was not possible to stop `./someguy start` via regular interrupt, so I've ported interrupt signal handling from rainbow. 

Graceful shutdown should help us avoid caching truncated streaming responses. 
Tested with `ab` tool, works as expected.