### PR TITLE
fix: enable hole punching and libp2p listener config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The following emojis are used to highlight certain changes:
 
 ### Security
 
+## [v0.4.1]
+
+### Fixed
+
+- enabled NAT port map and Hole Punching to increase connectivity in non-public network topologies
+
 ## [v0.4.0]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ The following emojis are used to highlight certain changes:
 
 ## [v0.4.1]
 
+### Added
+
+- `SOMEGUY_LIBP2P_LISTEN_ADDRS` config [environment variable](./docs/environment-variables.md#someguy_libp2p_listen_addrs) for customizing the interfaces, ports, and transports of the libp2p host created by someguy.
+
 ### Fixed
 
 - enabled NAT port map and Hole Punching to increase connectivity in non-public network topologies

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -8,6 +8,7 @@
   - [`SOMEGUY_PROVIDER_ENDPOINTS`](#someguy_provider_endpoints)
   - [`SOMEGUY_PEER_ENDPOINTS`](#someguy_peer_endpoints)
   - [`SOMEGUY_IPNS_ENDPOINTS`](#someguy_ipns_endpoints)
+  - [`SOMEGUY_LIBP2P_LISTEN_ADDRS`](#someguy_libp2p_listen_addrs)
   - [`SOMEGUY_LIBP2P_CONNMGR_LOW`](#someguy_libp2p_connmgr_low)
   - [`SOMEGUY_LIBP2P_CONNMGR_HIGH`](#someguy_libp2p_connmgr_high)
   - [`SOMEGUY_LIBP2P_CONNMGR_GRACE_PERIOD`](#someguy_libp2p_connmgr_grace_period)
@@ -50,6 +51,12 @@ Default: none
 Comma-separated list of other Delegated Routing V1 endpoints to proxy IPNS requests to.
 
 Default: none
+
+### `SOMEGUY_LIBP2P_LISTEN_ADDRS`
+
+Multiaddresses for libp2p host to listen on (comma-separated).
+
+Default: `someguy start --help`
 
 ### `SOMEGUY_LIBP2P_CONNMGR_LOW`
 

--- a/main.go
+++ b/main.go
@@ -54,6 +54,20 @@ func main() {
 						EnvVars: []string{"SOMEGUY_IPNS_ENDPOINTS"},
 						Usage:   "other Delegated Routing V1 endpoints to proxy IPNS requests to",
 					},
+					&cli.StringSliceFlag{
+						Name: "libp2p-listen-addrs",
+						Value: cli.NewStringSlice(
+							"/ip4/0.0.0.0/tcp/4004",
+							"/ip4/0.0.0.0/udp/4004/quic-v1",
+							"/ip4/0.0.0.0/udp/4004/webrtc-direct",
+							"/ip4/0.0.0.0/udp/4004/quic-v1/webtransport",
+							"/ip6/::/tcp/4004",
+							"/ip6/::/udp/4004/quic-v1",
+							"/ip6/::/udp/4004/webrtc-direct",
+							"/ip6/::/udp/4004/quic-v1/webtransport"),
+						EnvVars: []string{"SOMEGUY_LIBP2P_LISTEN_ADDRS"},
+						Usage:   "Multiaddresses for libp2p host to listen on (comma-separated)",
+					},
 					&cli.IntFlag{
 						Name:    "libp2p-connmgr-low",
 						Value:   100,
@@ -94,11 +108,12 @@ func main() {
 						peerEndpoints:    ctx.StringSlice("peer-endpoints"),
 						ipnsEndpoints:    ctx.StringSlice("ipns-endpoints"),
 
-						connMgrLow:   ctx.Int("libp2p-connmgr-low"),
-						connMgrHi:    ctx.Int("libp2p-connmgr-high"),
-						connMgrGrace: ctx.Duration("libp2p-connmgr-grace"),
-						maxMemory:    ctx.Uint64("libp2p-max-memory"),
-						maxFD:        ctx.Int("libp2p-max-fd"),
+						libp2pListenAddress: ctx.StringSlice("libp2p-listen-addrs"),
+						connMgrLow:          ctx.Int("libp2p-connmgr-low"),
+						connMgrHi:           ctx.Int("libp2p-connmgr-high"),
+						connMgrGrace:        ctx.Duration("libp2p-connmgr-grace"),
+						maxMemory:           ctx.Uint64("libp2p-max-memory"),
+						maxFD:               ctx.Int("libp2p-max-fd"),
 					}
 
 					return start(ctx.Context, cfg)

--- a/main.go
+++ b/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/ipfs/boxo/ipns"
@@ -116,6 +118,13 @@ func main() {
 						maxFD:               ctx.Int("libp2p-max-fd"),
 					}
 
+					fmt.Printf("Starting %s %s\n", name, version)
+
+					fmt.Printf("SOMEGUY_ACCELERATED_DHT = %t\n", cfg.acceleratedDHTClient)
+					printIfListConfigured("SOMEGUY_PROVIDER_ENDPOINTS = ", cfg.contentEndpoints)
+					printIfListConfigured("SOMEGUY_PEER_ENDPOINTS = ", cfg.peerEndpoints)
+					printIfListConfigured("SOMEGUY_IPNS_ENDPOINTS = ", cfg.ipnsEndpoints)
+
 					return start(ctx.Context, cfg)
 				},
 			},
@@ -212,5 +221,11 @@ func main() {
 	err := app.Run(os.Args)
 	if err != nil {
 		log.Fatal(err)
+	}
+}
+
+func printIfListConfigured(message string, list []string) {
+	if len(list) > 0 {
+		fmt.Printf(message+"%v\n", strings.Join(list, ", "))
 	}
 }

--- a/server.go
+++ b/server.go
@@ -62,6 +62,7 @@ func start(ctx context.Context, cfg *config) error {
 		return err
 	}
 
+	fmt.Printf("Someguy libp2p host listening on %v\n", h.Addrs())
 	var dhtRouting routing.Routing
 	if cfg.acceleratedDHTClient {
 		wrappedDHT, err := newBundledDHT(ctx, h)
@@ -96,8 +97,6 @@ func start(ctx context.Context, cfg *config) error {
 	if err != nil {
 		return err
 	}
-
-	fmt.Printf("Starting %s %s\n", name, version)
 
 	mdlw := middleware.New(middleware.Config{
 		Recorder: metrics.NewRecorder(metrics.Config{Prefix: "someguy"}),
@@ -141,7 +140,6 @@ func start(ctx context.Context, cfg *config) error {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	fmt.Printf("Listening on %s\n", cfg.listenAddress)
 	fmt.Printf("Delegated Routing API on http://127.0.0.1:%s/routing/v1\n", port)
 
 	go func() {

--- a/server.go
+++ b/server.go
@@ -186,6 +186,10 @@ func newHost(cfg *config) (host.Host, error) {
 		libp2p.UserAgent("someguy/"+buildVersion()),
 		libp2p.ConnectionManager(cmgr),
 		libp2p.ResourceManager(rcmgr),
+		libp2p.NATPortMap(),
+		libp2p.DefaultTransports,
+		libp2p.DefaultMuxers,
+		libp2p.EnableHolePunching(),
 	)
 	if err != nil {
 		return nil, err

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.4.0"
+  "version": "v0.4.1"
 }


### PR DESCRIPTION
This PR proposes a patch release v0.4.1 that enables UPnP/hole punching bringing someguy closer to what Kubo does.

iiuc this does not hurt, and should help if someone is running someguy locally  or behind some restrictive NAT without public addr + hole punching is necessary to reach other NATd peers
