### PR TITLE
chore: remove redundant buildtag

### DIFF
--- a/internal/fd/sys_unix.go
+++ b/internal/fd/sys_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin
-// +build linux darwin
 
 // Package fd provides filesystem descriptor count for different architectures.
 package fd


### PR DESCRIPTION
`go:build` means the same, and that notation seems to be preferable:
https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md