### PR TITLE
fix: no implicit filtering of proxied IPNI results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The following emojis are used to highlight certain changes:
 
 ### Security
 
+## [v0.5.3]
+
+### Fixed
+
+- default config: restore proxying `transport-ipfs-gateway-http` results from IPNI at `cid.contact` [#83](https://github.com/ipfs/someguy/pull/85)
+
 ## [v0.5.2]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
-- default config: restore proxying `transport-ipfs-gateway-http` results from IPNI at `cid.contact` [#83](https://github.com/ipfs/someguy/pull/85)
+- default config: restore proxying of all results from IPNI at `cid.contact` [#83](https://github.com/ipfs/someguy/pull/85)
 
 ## [v0.5.2]
 

--- a/server.go
+++ b/server.go
@@ -217,12 +217,9 @@ func getCombinedRouting(endpoints []string, dht routing.Routing) (router, error)
 	for _, endpoint := range endpoints {
 		drclient, err := drclient.New(endpoint,
 			drclient.WithUserAgent("someguy/"+buildVersion()),
-			drclient.WithProtocolFilter([]string{
-				"unknown", // allow results without protocol list, allowing end user to do libp2p Identify probe to test them
-				"transport-bitswap",
-				"transport-ipfs-gateway-http",
-			}),
-			drclient.WithDisabledLocalFiltering(false), // force local filtering in case remote server does not support IPIP-484
+			// override default filters, we want all results from remote endpoint, then someguy's user can use IPIP-484 to narrow them down
+			drclient.WithProtocolFilter([]string{}),
+			drclient.WithDisabledLocalFiltering(true),
 		)
 		if err != nil {
 			return nil, err

--- a/server.go
+++ b/server.go
@@ -16,7 +16,7 @@ import (
 	"github.com/CAFxX/httpcompression"
 	sddaemon "github.com/coreos/go-systemd/v22/daemon"
 	"github.com/felixge/httpsnoop"
-	"github.com/ipfs/boxo/routing/http/client"
+	drclient "github.com/ipfs/boxo/routing/http/client"
 	"github.com/ipfs/boxo/routing/http/server"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
@@ -215,7 +215,15 @@ func getCombinedRouting(endpoints []string, dht routing.Routing) (router, error)
 	var routers []router
 
 	for _, endpoint := range endpoints {
-		drclient, err := client.New(endpoint, client.WithUserAgent(userAgent))
+		drclient, err := drclient.New(endpoint,
+			drclient.WithUserAgent("someguy/"+buildVersion()),
+			drclient.WithProtocolFilter([]string{
+				"unknown", // allow results without protocol list, allowing end user to do libp2p Identify probe to test them
+				"transport-bitswap",
+				"transport-ipfs-gateway-http",
+			}),
+			drclient.WithDisabledLocalFiltering(false), // force local filtering in case remote server does not support IPIP-484
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/version.go
+++ b/version.go
@@ -13,7 +13,6 @@ var versionJSON []byte
 
 var name = "someguy"
 var version = buildVersion()
-var userAgent = name + "/" + version
 
 func buildVersion() string {
 	// Read version from embedded JSON file.

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.5.2"
+  "version": "v0.5.3"
 }


### PR DESCRIPTION
## Problem

Because we don't have HTTP retrieval client in golang (boxo) yet, the [`DefaultProtocolFilter`](https://github.com/ipfs/boxo/blob/29598b2babb86cf508adb35940436db6445ff032/routing/http/client/client.go#L37) in `boxo/routing/http/client` does not include `transport-ipfs-gateway-http` yet.



This had unintended consequence at delegated-ipfs.dev because  someguy as a proxy CLIENT to `https://cid.contact/routing/v1`, was running with default filters and as a client, was filtering `transport-ipfs-gateway-http` out.


Then, when acting as delegated routing SERVER, it no longer had them, which made these results unavailable to JS clients, even when they DO have HTTP support (e.g. SW gateway at https://inbrowser.link), even if they included it in explicit `?filter-protocols=unknown,transport-bitswap,transport-ipfs-gateway-http` queries sent to  delegated-ipfs.dev.

cc @2color  @SgtPooki for visibility

## Fix

This PR overrides implicit delegated routing CLIENT filters with explicit empty one.

This restores those IPNI results (from cid.contact), allowing clients that need them, to get them.

(clients that that do not need them, can still skip them by passing explicit `filter-protocol` list without this protocol)

##  Before (v0.5.2)

```console
$ curl 'https://delegated-ipfs.dev/routing/v1/providers/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi' -H 'Accept: application/x-ndjson' -s | grep transport-ipfs-gateway-http
...
```

(no `transport-ipfs-gateway-http` results)

## After  (this PR, once merged will be v0.5.3)

```console
$ go run . start
$ curl 'http://127.0.0.1:8190/routing/v1/providers/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi' -H 'Accept: application/x-ndjson' -s | grep transport-ipfs-gateway-http
{"Addrs":["/dns4/dag.w3s.link/tcp/443/https"],"ID":"QmUA9D3H7HeCYsirB3KmPSvZh3dNXMZas6Lwgr4fv1HTTp","Protocols":["transport-ipfs-gateway-http"],"Schema":"peer","transport-ipfs-gateway-http":"oBIA"}
{"Addrs":["/ip4/212.6.53.27/tcp/80/http"],"ID":"12D3KooWHEzPJNmo4shWendFFrxDNttYf8DW4eLC7M2JzuXHC1hE","Protocols":["transport-ipfs-gateway-http"],"Schema":"peer","transport-ipfs-gateway-http":"oBIA"}
{"Addrs":["/ip4/212.6.53.28/tcp/80/http"],"ID":"12D3KooWJ8YAF6DiRxrzcxoeUVjSANYxyxU55ruFgNvQB4EHibpG","Protocols":["transport-ipfs-gateway-http"],"Schema":"peer","transport-ipfs-gateway-http":"oBIA"}
```
