### PR TITLE
fix: use sanitize router only for DHT

### DIFF
--- a/server.go
+++ b/server.go
@@ -236,9 +236,9 @@ func getCombinedRouting(endpoints []string, dht routing.Routing) (router, error)
 		routers = append(routers, clientRouter{Client: drclient})
 	}
 
-	return sanitizeRouter{parallelRouter{
-		routers: append(routers, libp2pRouter{routing: dht}),
-	}}, nil
+	return parallelRouter{
+		routers: append(routers, sanitizeRouter{libp2pRouter{routing: dht}}),
+	}, nil
 }
 
 func withTracingAndDebug(next http.Handler, authToken string) http.Handler {


### PR DESCRIPTION
This PR changes the `getCombinedRouting` function and only applies the sanitizeRouter (which filters out private IPs) to the DHT router. 

The reason for this is that the IPNI shouldn't return private addresses so there's no need to sanitize results.