### PR TITLE
fix: filter public ips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,13 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
-
 ### Changed
 
 ### Removed
 
 ### Fixed
+
+- Fix a bug whereby, cached peers with private multiaddrs were returned in `/routing/v1/providers` responses, as they were not passing through `sanitizeRouter`.
 
 ### Security
 

--- a/server.go
+++ b/server.go
@@ -246,7 +246,8 @@ func getCombinedRouting(endpoints []string, dht routing.Routing, cachedAddrBook 
 	var dhtRouter router
 
 	if cachedAddrBook != nil {
-		dhtRouter = NewCachedRouter(sanitizeRouter{libp2pRouter{routing: dht}}, cachedAddrBook)
+		cachedRouter := NewCachedRouter(libp2pRouter{routing: dht}, cachedAddrBook)
+		dhtRouter = sanitizeRouter{cachedRouter}
 	} else {
 		dhtRouter = sanitizeRouter{libp2pRouter{routing: dht}}
 	}

--- a/server_cached_router.go
+++ b/server_cached_router.go
@@ -224,7 +224,6 @@ func (it *cacheFallbackIter) dispatchFindPeer(record types.PeerRecord) {
 	}
 	if len(peers) > 0 {
 		// If we found the peer, pass back the result
-		peers[0].Addrs = filterPrivateMultiaddr(peers[0].Addrs) // filter out private addresses
 		it.findPeersResult <- *peers[0]
 	} else {
 		it.findPeersResult <- record // pass back the record with no addrs

--- a/server_cached_router.go
+++ b/server_cached_router.go
@@ -48,6 +48,7 @@ const (
 )
 
 // cachedRouter wraps a router with the cachedAddrBook to retrieve cached addresses for peers without multiaddrs in FindProviders
+// it will also dispatch a FindPeer when a provider has no multiaddrs using the cacheFallbackIter
 type cachedRouter struct {
 	router
 	cachedAddrBook *cachedAddrBook

--- a/server_cached_router.go
+++ b/server_cached_router.go
@@ -223,6 +223,7 @@ func (it *cacheFallbackIter) dispatchFindPeer(record types.PeerRecord) {
 	}
 	if len(peers) > 0 {
 		// If we found the peer, pass back the result
+		peers[0].Addrs = filterPrivateMultiaddr(peers[0].Addrs) // filter out private addresses
 		it.findPeersResult <- *peers[0]
 	} else {
 		it.findPeersResult <- record // pass back the record with no addrs


### PR DESCRIPTION
## What does this fix?

This fixes a regression introduced with the cached router.

Because the `cachedRouter` was wrapping `sanitizeRouter`, any providers that has no addresses, were thus getting populated straight from cache without going through `sanitizeRouter`.

This resulted in us returning providers with private IPs.

## How does this fix

This PR ensures that whatever the cached router spews out, gets properly sanitised.

## Open question

- `sanitizeRouter` removes private IPs, but it doesn't remove records that have **no IPs**.  In theory, there's might be an edge case where we find records that only contain private IPs, that are then removed by `sanitizeRouter`, leading frontends/consumers of this to issue a subsequent calls. This seems pretty unlikely. 
  - Is it even possible for would a peer show up in `dht.FindPeer` with only private IPs (if you're connecting to Amino)? 
  - We can also make sure of this by adding a filter in the `sanitizeRouter`, but it seems like this might be unnecessary work. 