### PR TITLE
feat: enable cors for put requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- Enabled CORS for PUT requests to `/routing/v1/ipns`.
+
 ### Changed
 
 ### Removed

--- a/server.go
+++ b/server.go
@@ -144,7 +144,7 @@ func start(ctx context.Context, cfg *config) error {
 	// Add CORS.
 	handler = cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},
-		AllowedMethods: []string{http.MethodGet, http.MethodOptions},
+		AllowedMethods: []string{http.MethodGet, http.MethodOptions, http.MethodPut},
 		MaxAge:         600,
 	}).Handler(handler)
 


### PR DESCRIPTION
## Enable CORS

Someguy already supports delegated publishing of IPNS records. But currently, cross origin requests are blocked. By enabling, we can have tools make use of this from other origins. 