### PR TITLE
feat: enable using an HTTP block provider as a routing backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- `accelerated-dht` option was removed and replaced with a `dht` option which enables toggling between the standard client, accelerated client and being disabled
+
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
-- Added `http-block-provider-endpoints` and `http-block-provider-peerids` options to allow using a trustless gateway block provider as a content routing record source
+- Added `http-block-provider-endpoints` and `http-block-provider-peerids` options to enable using a [trustless HTTP gateway](https://specs.ipfs.tech/http-gateways/trustless-gateway/) as a source for synthetic content routing records.
+  - When the configured gateway responds with HTTP 200 to an HTTP HEAD request for a block (`HEAD /ipfs/{cid}?format=raw`), `FindProviders` returns a provider record containing a predefined PeerID and the HTTP gateway as a multiaddr with `/tls/http` suffix.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- Added `http-block-provider-endpoints` and `http-block-provider-peerids` options to allow using a trustless gateway block provider as a content routing record source
+
 ### Changed
 
 ### Removed

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -4,10 +4,15 @@
 
 - [Configuration](#configuration)
   - [`SOMEGUY_LISTEN_ADDRESS`](#someguy_listen_address)
-  - [`SOMEGUY_ACCELERATED_DHT`](#someguy_accelerated_dht)
+  - [`SOMEGUY_DHT`](#someguy_dht)
+  - [`SOMEGUY_CACHED_ADDR_BOOK`](#someguy_cached_addr_book)
+  - [`SOMEGUY_CACHED_ADDR_BOOK_RECENT_TTL`](#someguy_cached_addr_book_recent_ttl)
+  - [`SOMEGUY_CACHED_ADDR_BOOK_ACTIVE_PROBING`](#someguy_cached_addr_book_active_probing)
   - [`SOMEGUY_PROVIDER_ENDPOINTS`](#someguy_provider_endpoints)
   - [`SOMEGUY_PEER_ENDPOINTS`](#someguy_peer_endpoints)
   - [`SOMEGUY_IPNS_ENDPOINTS`](#someguy_ipns_endpoints)
+  - [`SOMEGUY_HTTP_BLOCK_PROVIDER_ENDPOINTS`](#someguy_http_block_provider_endpoints)
+  - [`SOMEGUY_HTTP_BLOCK_PROVIDER_PEERIDS`](#someguy_http_block_provider_peerids)
   - [`SOMEGUY_LIBP2P_LISTEN_ADDRS`](#someguy_libp2p_listen_addrs)
   - [`SOMEGUY_LIBP2P_CONNMGR_LOW`](#someguy_libp2p_connmgr_low)
   - [`SOMEGUY_LIBP2P_CONNMGR_HIGH`](#someguy_libp2p_connmgr_high)
@@ -20,8 +25,8 @@
   - [`GOLOG_FILE`](#golog_file)
   - [`GOLOG_TRACING_FILE`](#golog_tracing_file)
 - [Tracing](#tracing)
-  - [`SOMEGUY_SAMPLING_FRACTION`](#someguy_sampling_fraction)
   - [`SOMEGUY_TRACING_AUTH`](#someguy_tracing_auth)
+  - [`SOMEGUY_SAMPLING_FRACTION`](#someguy_sampling_fraction)
 
 ## Configuration
 
@@ -31,11 +36,11 @@ The address to listen on.
 
 Default: `127.0.0.1:8190`
 
-### `SOMEGUY_ACCELERATED_DHT`
+### `SOMEGUY_DHT`
 
-Whether or not the Accelerated DHT is enabled or not.
+Controls DHT client mode: `standard`, `accelerated`, `disabled`
 
-Default: `true`
+Default: `accelerated`
 
 ### `SOMEGUY_CACHED_ADDR_BOOK`
 
@@ -70,6 +75,20 @@ Default: none
 ### `SOMEGUY_IPNS_ENDPOINTS`
 
 Comma-separated list of other Delegated Routing V1 endpoints to proxy IPNS requests to.
+
+Default: none
+
+### `SOMEGUY_HTTP_BLOCK_PROVIDER_ENDPOINTS`
+
+Comma-separated list of [HTTP trustless gateway](https://specs.ipfs.tech/http-gateways/trustless-gateway/) for probing and generating synthetic provider records.
+
+When the configured gateway responds with HTTP 200 to an HTTP HEAD request for a block (`HEAD /ipfs/{cid}?format=raw`), `FindProviders` returns a provider record containing a PeerID from `SOMEGUY_HTTP_BLOCK_PROVIDER_PEERIDS` and the HTTP gateway endpoint as a multiaddr with `/tls/http` suffix.
+
+Default: none
+
+### `SOMEGUY_HTTP_BLOCK_PROVIDER_PEERIDS`
+
+Comma-separated list of [multibase-encoded peerIDs](https://github.com/libp2p/specs/blob/master/peer-ids/peer-ids.md#string-representation) to use in synthetic provider records returned for HTTP providers in `SOMEGUY_HTTP_BLOCK_PROVIDER_ENDPOINTS`.
 
 Default: none
 

--- a/http_block_provider.go
+++ b/http_block_provider.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 
@@ -61,8 +62,12 @@ func newHTTPBlockProvider(endpoint string, p peer.ID, client *http.Client) (http
 	var tlsComponent string
 	if u.Scheme == "https" {
 		tlsComponent = "/tls"
+	} else if os.Getenv("DEBUG") == "true" {
+		// allow unencrypted HTTP for local debugging
+		tlsComponent = ""
 	} else {
 		return httpBlockProvider{}, fmt.Errorf("failed to parse endpoint %s: only HTTPS providers are allowed (unencrypted HTTP can't be used in web browsers)", endpoint)
+
 	}
 
 	var httpPathComponent string
@@ -89,7 +94,7 @@ func (h httpBlockProvider) FindProviders(ctx context.Context, c cid.Cid, limit i
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/vnd.ipld.raw")
+	req.Header.Set("Accept", "application/vnd.ipld.raw")
 	httpClient := h.httpClient
 	if httpClient == nil {
 		httpClient = http.DefaultClient

--- a/http_block_provider.go
+++ b/http_block_provider.go
@@ -62,7 +62,7 @@ func newHTTPBlockProvider(endpoint string, p peer.ID, client *http.Client) (http
 	if u.Scheme == "https" {
 		tlsComponent = "/tls"
 	} else {
-		tlsComponent = ""
+		return httpBlockProvider{}, fmt.Errorf("failed to parse endpoint %s: only HTTPS providers are allowed (unencrypted HTTP can't be used in web browsers)", endpoint)
 	}
 
 	var httpPathComponent string

--- a/http_block_provider.go
+++ b/http_block_provider.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/ipfs/boxo/routing/http/types"
+	"github.com/ipfs/boxo/routing/http/types/iter"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+)
+
+type httpBlockProvider struct {
+	endpoint   string
+	endpointMa multiaddr.Multiaddr
+	peerID     peer.ID
+	httpClient *http.Client
+}
+
+func newHTTPBlockProvider(endpoint string, p peer.ID, client *http.Client) (httpBlockProvider, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return httpBlockProvider{}, fmt.Errorf("failed to parse endpoint %s: %w", endpoint, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return httpBlockProvider{}, fmt.Errorf("unsupported scheme %s, only http and https are supported", u.Scheme)
+	}
+
+	h := u.Hostname()
+	ip := net.ParseIP(h)
+	var hostComponent string
+	if ip == nil {
+		hostComponent = "dns"
+	} else if strings.Contains(h, ":") {
+		hostComponent = "ip6"
+	} else {
+		hostComponent = "ip4"
+	}
+
+	var port int
+	if u.Port() != "" {
+		if p, err := strconv.Atoi(u.Port()); err != nil {
+			return httpBlockProvider{}, fmt.Errorf("invalid port %s: %w", u.Port(), err)
+		} else {
+			port = p
+		}
+	} else {
+		if u.Scheme == "https" {
+			port = 443
+		} else {
+			port = 80
+		}
+	}
+
+	var tlsComponent string
+	if u.Scheme == "https" {
+		tlsComponent = "/tls"
+	} else {
+		tlsComponent = ""
+	}
+
+	var httpPathComponent string
+	if escPath := u.EscapedPath(); escPath != "" && escPath != "/" {
+		httpPathComponent = "/http-path" + escPath
+	}
+
+	endpointMaStr := fmt.Sprintf("/%s/%s/tcp/%d%s/http%s", hostComponent, h, port, tlsComponent, httpPathComponent)
+
+	ma, err := multiaddr.NewMultiaddr(endpointMaStr)
+	if err != nil {
+		return httpBlockProvider{}, fmt.Errorf("failed to parse endpoint %s: %w", endpoint, err)
+	}
+	return httpBlockProvider{
+		endpoint:   endpoint,
+		endpointMa: ma,
+		peerID:     p,
+		httpClient: client,
+	}, nil
+}
+
+func (h httpBlockProvider) FindProviders(ctx context.Context, c cid.Cid, limit int) (iter.ResultIter[types.Record], error) {
+	req, err := http.NewRequestWithContext(ctx, "HEAD", fmt.Sprintf("%s/ipfs/%s?format=raw", h.endpoint, c), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/vnd.ipld.raw")
+	httpClient := h.httpClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusOK {
+		return iter.ToResultIter(iter.FromSlice([]types.Record{
+			&types.PeerRecord{
+				Schema: types.SchemaPeer,
+				ID:     &h.peerID,
+				Addrs: []types.Multiaddr{
+					{Multiaddr: h.endpointMa},
+				},
+				Protocols: []string{"transport-ipfs-gateway-http"},
+				Extra:     nil,
+			},
+		})), nil
+	}
+	return iter.ToResultIter(iter.FromSlice([]types.Record{})), nil
+}
+
+var _ providersRouter = (*httpBlockProvider)(nil)

--- a/http_block_provider.go
+++ b/http_block_provider.go
@@ -67,7 +67,7 @@ func newHTTPBlockProvider(endpoint string, p peer.ID, client *http.Client) (http
 
 	var httpPathComponent string
 	if escPath := u.EscapedPath(); escPath != "" && escPath != "/" {
-		httpPathComponent = "/http-path" + escPath
+		return httpBlockProvider{}, fmt.Errorf("failed to parse endpoint %s: only URLs without path are supported", endpoint)
 	}
 
 	endpointMaStr := fmt.Sprintf("/%s/%s/tcp/%d%s/http%s", hostComponent, h, port, tlsComponent, httpPathComponent)

--- a/http_block_router_test.go
+++ b/http_block_router_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/boxo/routing/http/types"
+	"github.com/ipfs/boxo/routing/http/types/iter"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPBlockRouter(t *testing.T) {
+	t.Parallel()
+	debug := os.Getenv("DEBUG") == "true"
+
+	t.Run("FindProviders", func(t *testing.T) {
+		ctx := context.Background()
+		// Set up mock HTTP Provider (trustless gateway) that returns HTTP 200 for specific CID
+		testData := "Thu  8 May 01:07:03 CEST 2025"
+		testCid := cid.MustParse("bafkreie5zycmytdhd5bl4f5jqsayyiwshugf57d4hkd7eif3toh23fsy3i")
+		httpBlockGateway := newMockTrustlessGateway(testCid, testData, debug)
+		t.Cleanup(func() { httpBlockGateway.Close() })
+
+		// Test args
+		endpoint := httpBlockGateway.URL
+		peerId, _ := peer.Decode("12D3KooWCjfPiojcCUmv78Wd1NJzi4Mraj1moxigp7AfQVQvGLwH")
+		insecureSkipVerify := true
+		client := defaultHTTPBlockRouterClient(insecureSkipVerify)
+		httpHost, httpPort, err := splitHostPort(endpoint)
+		assert.NoError(t, err)
+		expectedAddr := fmt.Sprintf("/ip4/%s/tcp/%s/tls/http", httpHost, httpPort)
+
+		// Create Router
+		httpBlockRouter, err := newHTTPBlockRouter(endpoint, peerId, client)
+		assert.NoError(t, err)
+
+		t.Run("return gateway as HTTP provider if HTTP HEAD check returned HTTP 200", func(t *testing.T) {
+			t.Parallel()
+
+			// Ask Router for CID present on trustless gateway
+			it, err := httpBlockRouter.FindProviders(ctx, testCid, 10)
+			require.NoError(t, err)
+
+			results, err := iter.ReadAllResults(it)
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+
+			// Verify returned provider points at http gateway URL
+			peerRecord := results[0].(*types.PeerRecord)
+			require.Equal(t, peerId, *peerRecord.ID)
+			require.Len(t, peerRecord.Addrs, 1)
+			assert.NoError(t, err)
+			require.Equal(t, expectedAddr, peerRecord.Addrs[0].String())
+		})
+
+		t.Run("return no results if HTTP HEAD check returned HTTP 404", func(t *testing.T) {
+			t.Parallel()
+
+			// This CID has no providers
+			failCid := cid.MustParse("bafkreie5keu4z5kgutjds5tz3ahdxhcdkn4hl2vr7snenml44ui7y4yfki")
+
+			// Ask Router for CID present on trustless gateway
+			it, err := httpBlockRouter.FindProviders(ctx, failCid, 10)
+			require.NoError(t, err)
+
+			results, err := iter.ReadAllResults(it)
+			require.NoError(t, err)
+			require.Len(t, results, 0)
+		})
+
+	})
+}
+
+// newMockTrustlessGateway pretends to be http provider that supports
+// block response https://specs.ipfs.tech/http-gateways/trustless-gateway/#block-responses-application-vnd-ipld-raw
+func newMockTrustlessGateway(c cid.Cid, body string, debug bool) *httptest.Server {
+	expectedPathPrefix := "/ipfs/" + c.String()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if debug {
+			fmt.Printf("mockTrustlessGateway %s %s\n", req.Method, req.URL.Path)
+		}
+		if strings.HasPrefix(req.URL.Path, expectedPathPrefix) {
+			w.Header().Set("Content-Type", "application/vnd.ipld.raw")
+			w.WriteHeader(http.StatusOK)
+			if req.Method == "GET" {
+				_, err := w.Write([]byte(body))
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "mockTrustlessGateway %s %s error: %v\n", req.Method, req.URL.Path, err)
+				}
+			}
+			return
+		} else if strings.HasPrefix(req.URL.Path, "/ipfs/bafkqaaa") {
+			// This is probe from https://specs.ipfs.tech/http-gateways/trustless-gateway/#dedicated-probe-paths
+			w.Header().Set("Content-Type", "application/vnd.ipld.raw")
+			w.WriteHeader(http.StatusOK)
+			return
+		} else {
+			http.Error(w, "Not Found", http.StatusNotFound)
+			return
+		}
+	})
+
+	// Make it HTTP/2 with self-signed TLS cert
+	srv := httptest.NewUnstartedServer(handler)
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	return srv
+}
+
+func splitHostPort(httpUrl string) (ipAddr string, port string, err error) {
+	u, err := url.Parse(httpUrl)
+	if err != nil {
+		return "", "", err
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", "", fmt.Errorf("invalid URL format: missing scheme or host")
+	}
+	ipAddr, port, err = net.SplitHostPort(u.Host)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to split host and port from %q: %w", u.Host, err)
+	}
+	return ipAddr, port, nil
+}

--- a/main.go
+++ b/main.go
@@ -32,11 +32,11 @@ func main() {
 						EnvVars: []string{"SOMEGUY_LISTEN_ADDRESS"},
 						Usage:   "listen address",
 					},
-					&cli.BoolFlag{
-						Name:    "accelerated-dht",
-						Value:   true,
-						EnvVars: []string{"SOMEGUY_ACCELERATED_DHT"},
-						Usage:   "run the accelerated DHT client",
+					&cli.StringFlag{
+						Name:    "dht",
+						Value:   "accelerated",
+						EnvVars: []string{"SOMEGUY_DHT"},
+						Usage:   "mode with which to run the Amino DHT client. Options are 'accelerated' or 'standard' or 'disabled'.",
 					},
 					&cli.BoolFlag{
 						Name:    "cached-addr-book",
@@ -147,7 +147,7 @@ func main() {
 				Action: func(ctx *cli.Context) error {
 					cfg := &config{
 						listenAddress:               ctx.String("listen-address"),
-						acceleratedDHTClient:        ctx.Bool("accelerated-dht"),
+						dhtType:                     ctx.String("dht"),
 						cachedAddrBook:              ctx.Bool("cached-addr-book"),
 						cachedAddrBookActiveProbing: ctx.Bool("cached-addr-book-active-probing"),
 						cachedAddrBookRecentTTL:     ctx.Duration("cached-addr-book-recent-ttl"),
@@ -171,7 +171,7 @@ func main() {
 
 					fmt.Printf("Starting %s %s\n", name, version)
 
-					fmt.Printf("SOMEGUY_ACCELERATED_DHT = %t\n", cfg.acceleratedDHTClient)
+					fmt.Printf("SOMEGUY_DHT = %s\n", cfg.dhtType)
 					printIfListConfigured("SOMEGUY_PROVIDER_ENDPOINTS = ", cfg.contentEndpoints)
 					printIfListConfigured("SOMEGUY_PEER_ENDPOINTS = ", cfg.peerEndpoints)
 					printIfListConfigured("SOMEGUY_IPNS_ENDPOINTS = ", cfg.ipnsEndpoints)

--- a/main.go
+++ b/main.go
@@ -64,6 +64,18 @@ func main() {
 						Usage:   "other Delegated Routing V1 endpoints to proxy provider requests to",
 					},
 					&cli.StringSliceFlag{
+						Name:    "http-block-provider-endpoints",
+						Value:   nil,
+						EnvVars: []string{"SOMEGUY_HTTP_BLOCK_PROVIDER_ENDPOINTS"},
+						Usage:   "list of HTTP trustless gateway endpoints to proxy provider requests to",
+					},
+					&cli.StringSliceFlag{
+						Name:    "http-block-provider-peerids",
+						Value:   nil,
+						EnvVars: []string{"SOMEGUY_HTTP_BLOCK_PROVIDER_PEERIDS"},
+						Usage:   "list of peerIDs for the HTTP trustless gateway endpoints to proxy provider requests to",
+					},
+					&cli.StringSliceFlag{
 						Name:    "peer-endpoints",
 						Value:   cli.NewStringSlice(),
 						EnvVars: []string{"SOMEGUY_PEER_ENDPOINTS"},
@@ -140,9 +152,11 @@ func main() {
 						cachedAddrBookActiveProbing: ctx.Bool("cached-addr-book-active-probing"),
 						cachedAddrBookRecentTTL:     ctx.Duration("cached-addr-book-recent-ttl"),
 
-						contentEndpoints: ctx.StringSlice("provider-endpoints"),
-						peerEndpoints:    ctx.StringSlice("peer-endpoints"),
-						ipnsEndpoints:    ctx.StringSlice("ipns-endpoints"),
+						contentEndpoints:       ctx.StringSlice("provider-endpoints"),
+						peerEndpoints:          ctx.StringSlice("peer-endpoints"),
+						ipnsEndpoints:          ctx.StringSlice("ipns-endpoints"),
+						blockProviderEndpoints: ctx.StringSlice("http-block-provider-endpoints"),
+						blockProviderPeerIDs:   ctx.StringSlice("http-block-provider-peerids"),
 
 						libp2pListenAddress: ctx.StringSlice("libp2p-listen-addrs"),
 						connMgrLow:          ctx.Int("libp2p-connmgr-low"),
@@ -161,6 +175,8 @@ func main() {
 					printIfListConfigured("SOMEGUY_PROVIDER_ENDPOINTS = ", cfg.contentEndpoints)
 					printIfListConfigured("SOMEGUY_PEER_ENDPOINTS = ", cfg.peerEndpoints)
 					printIfListConfigured("SOMEGUY_IPNS_ENDPOINTS = ", cfg.ipnsEndpoints)
+					printIfListConfigured("SOMEGUY_HTTP_BLOCK_PROVIDER_ENDPOINTS = ", cfg.blockProviderEndpoints)
+					printIfListConfigured("SOMEGUY_HTTP_BLOCK_PROVIDER_PEERIDS = ", cfg.blockProviderPeerIDs)
 
 					return start(ctx.Context, cfg)
 				},

--- a/server.go
+++ b/server.go
@@ -121,7 +121,7 @@ func start(ctx context.Context, cfg *config) error {
 				return fmt.Errorf("invalid peer ID %s: %w", cfg.blockProviderPeerIDs[i], err)
 			}
 
-			r, err := newHTTPBlockProvider(endpoint, p, nil)
+			r, err := newHTTPBlockRouter(endpoint, p, nil)
 			if err != nil {
 				return err
 			}

--- a/server.go
+++ b/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/libp2p/go-libp2p/core/peer"
 	"log"
 	"net"
 	"net/http"
@@ -13,6 +12,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/CAFxX/httpcompression"
 	sddaemon "github.com/coreos/go-systemd/v22/daemon"
@@ -119,13 +120,8 @@ func start(ctx context.Context, cfg *config) error {
 			if err != nil {
 				return fmt.Errorf("invalid peer ID %s: %w", cfg.blockProviderPeerIDs[i], err)
 			}
-			r, err := newHTTPBlockProvider(endpoint, p, &http.Client{
-				Transport: &drclient.ResponseBodyLimitedTransport{
-					RoundTripper: http.DefaultTransport,
-					LimitBytes:   1 << 20,
-					UserAgent:    "someguy/" + buildVersion(),
-				},
-			})
+
+			r, err := newHTTPBlockProvider(endpoint, p, nil)
 			if err != nil {
 				return err
 			}

--- a/server_test.go
+++ b/server_test.go
@@ -10,15 +10,15 @@ func TestGetCombinedRouting(t *testing.T) {
 	t.Parallel()
 
 	// Check of the result of get combined routing is a sanitize router.
-	v, err := getCombinedRouting(nil, &bundledDHT{}, nil)
+	v, err := getCombinedRouting(nil, &bundledDHT{}, nil, nil)
 	require.NoError(t, err)
 	require.IsType(t, sanitizeRouter{}, v)
 
-	v, err = getCombinedRouting([]string{"https://example.com/"}, nil, nil)
+	v, err = getCombinedRouting([]string{"https://example.com/"}, nil, nil, nil)
 	require.NoError(t, err)
 	require.IsType(t, parallelRouter{}, v)
 
-	v, err = getCombinedRouting([]string{"https://example.com/"}, &bundledDHT{}, nil)
+	v, err = getCombinedRouting([]string{"https://example.com/"}, &bundledDHT{}, nil, nil)
 	require.NoError(t, err)
 	require.IsType(t, parallelRouter{}, v)
 }


### PR DESCRIPTION
fixes #109

- [x] cc @lidel took an initial stab, feel free to change whatever you want here.
- [x] ability to disable DHT and only run this to expose /routing/v1/providers/{cid} for preexisting gateway
- [x] 5s timeout as precaution (in case someone points this at recursive one, or under load)
- [x] add tests for HTTP 200 and 404
- [x] update `docs/environment-variables.md`

### Demo

Start someguy as `/routing/v1` proxy for gateway at `dag.w3s.link`:
```console
$ SOMEGUY_HTTP_BLOCK_PROVIDER_ENDPOINTS="https://dag.w3s.link" SOMEGUY_HTTP_BLOCK_PROVIDER_PEERIDS="QmaSDHYKwuUKTvnsGwqutEZWg5jrpzLJhDHaYRQ9VvrDyZ" SOMEGUY_DHT=disabled ./someguy start
```

CID that is at `dag.w3s.link`:
```console
$ curl http://127.0.0.1:8190/routing/v1/providers/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi -H "Accept: application/x-ndjson"
{"Addrs":["/dns/dag.w3s.link/tcp/443/tls/http"],"ID":"QmaSDHYKwuUKTvnsGwqutEZWg5jrpzLJhDHaYRQ9VvrDyZ","Protocols":["transport-ipfs-gateway-http"],"Schema":"peer"}
```

If CID is not at  gateway, there will be no providers returned. 