### PR TITLE
chore: modernize docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,13 +28,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -58,12 +51,10 @@ jobs:
           push: true
           file: ./Dockerfile
           tags: "${{ steps.tags.outputs.value }}"
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: |
+            type=gha
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: |
+            type=gha,mode=max
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache to limit growth
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
+# syntax=docker/dockerfile:1
 # Builder
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.23-bookworm AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.25-bookworm AS builder
 
 LABEL org.opencontainers.image.source=https://github.com/ipfs/someguy
 LABEL org.opencontainers.image.documentation=https://github.com/ipfs/someguy#docker
@@ -8,17 +9,20 @@ LABEL org.opencontainers.image.licenses=MIT+APACHE_2.0
 
 ARG TARGETPLATFORM TARGETOS TARGETARCH
 
-ENV GOPATH      /go
-ENV SRC_PATH    $GOPATH/src/github.com/ipfs/someguy
-ENV GO111MODULE on
-ENV GOPROXY     https://proxy.golang.org
+ENV GOPATH=/go
+ENV SRC_PATH=$GOPATH/src/github.com/ipfs/someguy
+ENV GO111MODULE=on
+ENV GOPROXY=https://proxy.golang.org
 
-COPY go.* $SRC_PATH/
+COPY go.mod go.sum $SRC_PATH/
 WORKDIR $SRC_PATH
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . $SRC_PATH
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o $GOPATH/bin/someguy
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o $GOPATH/bin/someguy
 
 # Runner
 FROM debian:bookworm-slim
@@ -27,9 +31,9 @@ RUN apt-get update && \
   apt-get install --no-install-recommends -y tini ca-certificates curl && \
   rm -rf /var/lib/apt/lists/*
 
-ENV GOPATH      /go
-ENV SRC_PATH    $GOPATH/src/github.com/ipfs/someguy
-ENV DATA_PATH   /data/someguy
+ENV GOPATH=/go
+ENV SRC_PATH=$GOPATH/src/github.com/ipfs/someguy
+ENV DATA_PATH=/data/someguy
 
 COPY --from=builder $GOPATH/bin/someguy /usr/local/bin/someguy
 


### PR DESCRIPTION
Chore cleanup of warnings from https://github.com/ipfs/someguy/actions/runs/17711695295/job/50331211534 + applying modern approach that already works in Kubo

- update to go 1.25
- add buildkit syntax and cache mounts
- fix deprecated ENV syntax
- switch from local to gha cache in workflow