### PR TITLE
refactor: apply go fix modernizers from Go 1.26

### DIFF
--- a/autoconf.go
+++ b/autoconf.go
@@ -82,9 +82,9 @@ func normalizeEndpointURL(url, expectedPath, flagName string) (string, error) {
 	}
 
 	// Check if URL has the expected routing path
-	if strings.HasSuffix(url, expectedPath) {
+	if before, ok := strings.CutSuffix(url, expectedPath); ok {
 		// Strip the expected path to get base URL
-		return strings.TrimSuffix(url, expectedPath), nil
+		return before, nil
 	}
 
 	// Check if URL has a different routing path (potential misconfiguration)

--- a/cached_addr_book.go
+++ b/cached_addr_book.go
@@ -147,7 +147,7 @@ func newCachedAddrBook(opts ...AddrBookOption) (*cachedAddrBook, error) {
 }
 
 func (cab *cachedAddrBook) background(ctx context.Context, host host.Host) {
-	sub, err := host.EventBus().Subscribe([]interface{}{
+	sub, err := host.EventBus().Subscribe([]any{
 		&event.EvtPeerIdentificationCompleted{},
 		&event.EvtPeerConnectednessChanged{},
 	})

--- a/cached_addr_book_test.go
+++ b/cached_addr_book_test.go
@@ -78,8 +78,7 @@ func TestBackground(t *testing.T) {
 }
 
 func TestProbePeers(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Create a test libp2p host
 	mockHost := &mockHost{}

--- a/server_dht_test.go
+++ b/server_dht_test.go
@@ -50,7 +50,7 @@ func makePeerRecords(t *testing.T, count int) ([]iter.Result[*types.PeerRecord],
 	var peerRecords []iter.Result[*types.PeerRecord]
 	var peerIDs []peer.ID
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		_, p := makeEd25519PeerID(t)
 		peerIDs = append(peerIDs, p)
 

--- a/server_routers_test.go
+++ b/server_routers_test.go
@@ -596,8 +596,7 @@ func TestManyIter(t *testing.T) {
 	t.Run("Sequence", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		its := newMockIters[int](ctx, 2)
 		manyIter := newManyIter(ctx, mockItersAsInterface(its))
@@ -632,8 +631,7 @@ func TestManyIter(t *testing.T) {
 	t.Run("Closed Iterator", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		its := newMockIters[int](ctx, 5)
 		manyIter := newManyIter(ctx, mockItersAsInterface(its))


### PR DESCRIPTION
This PR applies automated refactoring from go 1.26 (go fix ./...):

interface{} to any, slices.Contains, range loops and other idiomatic updates.